### PR TITLE
Fix link to API reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Datalib is a JavaScript data utility library. It provides facilities for data loading, type inference, common statistics, and string templates. While created to power [Vega](http://vega.github.io) and related projects, datalib is a standalone library useful for data-driven JavaScript applications on both the client (web browser) and server (e.g., node.js).
 
-For documentation, see the datalib [API Reference](API-Reference).
+For documentation, see the datalib [API Reference](../../wiki/API-Reference).
 
 ## Use
 


### PR DESCRIPTION
The current API Reference link is pointing to a location within the source tree, which doesn't exist. I updated the path to point to the wiki.