### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,31 @@
+{
+  "name": "datalib",
+  "main": "src/index.js",
+  "version": "1.0.11",
+  "homepage": "http://github.com/uwdata/datalib.git",
+  "authors": [
+    "UW Interactive Data Lab (http://idl.cs.washington.edu)"
+  ],
+  "description": "JavaScript utilites for loading, summarizing and working with data.",
+  "moduleType": [
+    "node"
+  ],
+  "keywords": [
+    "data",
+    "table",
+    "statistics",
+    "parse",
+    "csv",
+    "tsv",
+    "json",
+    "utility"
+  ],
+  "license": "BSD-3-Clause",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
- Added bower.json and register `datalib` in bower’s directory.  Now people can also install datalib with bower.   (`bower install datalib`)