### PR TITLE
adding string length calculation 

### DIFF
--- a/src/stats.js
+++ b/src/stats.js
@@ -142,6 +142,14 @@ stats.extent = function(values, f) {
   return [a, b];
 };
 
+stats.length = {};
+stats.length.extent = function(values, f) {
+  return stats.extent(values, function(x) {
+    var fx = f ? f(x) : x;
+    return fx.toString().length;
+  });
+};
+
 // Find the integer indices of the minimum and maximum values.
 stats.extent.index = function(values, f) {
   var a, b, x, y, v, i, n = values.length;
@@ -170,7 +178,7 @@ stats.dot = function(values, a, b) {
       v = values[i] * a[i];
       if (!isNaN(v)) sum += v;
     }
-  } else {  
+  } else {
     for (i=0; i<values.length; ++i) {
       v = a(values[i]) * b(values[i]);
       if (!isNaN(v)) sum += v;
@@ -279,7 +287,7 @@ stats.dist = function(values, a, b, exp) {
       d = f ? (a(X[i])-b(Y[i])) : (X[i]-Y[i]);
       s += d*d;
     }
-    return Math.sqrt(s); 
+    return Math.sqrt(s);
   } else {
     for (i=0; i<n; ++i) {
       d = Math.abs(f ? (a(X[i])-b(Y[i])) : (X[i]-Y[i]));

--- a/src/stats.js
+++ b/src/stats.js
@@ -391,9 +391,10 @@ stats.profile = function(values, f) {
       distinct = 0,
       min = null,
       max = null,
+      length = {max: -1, min: Number.POSITIVE_INFINITY},
       M2 = 0,
       vals = [],
-      u = {}, delta, sd, i, v, x, half, h, h2;
+      u = {}, delta, sd, i, v, x, half, h, h2, profile;
 
   // compute summary stats
   for (i=0, c=0; i<values.length; ++i) {
@@ -410,8 +411,12 @@ stats.profile = function(values, f) {
       x = (typeof v === 'string') ? v.length : v;
       delta = x - mean;
       mean = mean + delta / (++count);
-      M2 = M2 + delta * (x - mean);
+      M2 = M2 + delta * delta;
       vals.push(x);
+      if (typeof v === 'string') {
+        length.max = Math.max(v.length, length.max);
+        length.min = Math.min(v.length, length.min);
+      }
     }
   }
   M2 = M2 / (count - 1);
@@ -420,7 +425,7 @@ stats.profile = function(values, f) {
   // sort values for median and iqr
   vals.sort(util.cmp);
 
-  return {
+  profile = {
     unique:   u,
     count:    count,
     nulls:    values.length - count,
@@ -431,8 +436,10 @@ stats.profile = function(values, f) {
     stdev:    sd,
     median:   (v = stats.quantile(vals, 0.5)),
     modeskew: sd === 0 ? 0 : (mean - v) / sd,
-    iqr:      [stats.quantile(vals, 0.25), stats.quantile(vals, 0.75)]
+    iqr:      [stats.quantile(vals, 0.25), stats.quantile(vals, 0.75)],
   };
+  if (length.max !== -1) profile.length = length;
+  return profile;
 };
 
 module.exports = stats;

--- a/src/stats.js
+++ b/src/stats.js
@@ -411,7 +411,7 @@ stats.profile = function(values, f) {
       x = (typeof v === 'string') ? v.length : v;
       delta = x - mean;
       mean = mean + delta / (++count);
-      M2 = M2 + delta * delta;
+      M2 = M2 + delta * (x - mean);
       vals.push(x);
       if (typeof v === 'string') {
         length.max = Math.max(v.length, length.max);

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -43,7 +43,7 @@ describe('stats', function() {
       assert.equal(stats.count([3, 1, 2]), 3);
       assert.equal(stats.count([null, 1, 2, null]), 2);
     });
-    
+
     it('should count NaN values', function() {
       assert.equal(stats.count([NaN, 1, 2]), 3);
     });
@@ -52,13 +52,13 @@ describe('stats', function() {
       assert.equal(stats.count([1, undefined, 2, undefined, 3]), 3);
     });
   });
-  
+
   describe('count.distinct', function() {
     it('should count distinct values', function() {
       assert.equal(stats.count.distinct([3, 1, 2]), 3);
       assert.equal(stats.count.distinct([1, 1, 2, 1, 2, 3, 1, 2, 3, 3, 3]), 3);
     });
-    
+
     it('should recognize null values', function() {
       assert.equal(stats.count.distinct([null, 1, 2]), 3);
     });
@@ -73,13 +73,21 @@ describe('stats', function() {
       assert.equal(stats.count.nulls([3, 1, 2]), 0);
       assert.equal(stats.count.nulls([null, 0, 1, 2, null]), 2);
     });
-    
+
     it('should ignore NaN values', function() {
       assert.equal(stats.count.nulls([NaN, 1, 2]), 0);
     });
 
     it('should count undefined values', function() {
       assert.equal(stats.count.nulls([1, undefined, 2, undefined, 3]), 2);
+    });
+  });
+
+  describe('length', function() {
+    it('should calculate min length and max length', function(){
+      var l = stats.length.extent(['aa','bbbbbbb', 'ccc']);
+      assert.equal(l[0], 2);
+      assert.equal(l[1], 7);
     });
   });
 
@@ -136,7 +144,7 @@ describe('stats', function() {
       assert.equal(stats.median([3, 1, 2]), 2);
       assert.equal(stats.median([-2, -2, -1, 1, 2, 2]), 0);
     });
-    
+
     it('should ignore null values', function() {
       assert.equal(stats.median([1, 2, null]), 1.5);
     });
@@ -159,19 +167,19 @@ describe('stats', function() {
       assert.equal(stats.quantile(a, 1.00), 4);
     });
   });
-  
+
   describe('mean', function() {
     it('should calculate mean values', function() {
       assert.closeTo(stats.mean([3, 1, 2]), 2, EPSILON);
       assert.closeTo(stats.mean([-2, -2, -1, 1, 2, 2]), 0, EPSILON);
       assert.closeTo(stats.mean([4, 5]), 4.5, EPSILON);
     });
-    
+
     it('should ignore null values', function() {
       assert.closeTo(stats.mean([1, 2, null]), 1.5, EPSILON);
     });
   });
-  
+
   describe('rank', function() {
     it('should calculate rank values', function() {
       assert.deepEqual([1,   3,   2, 4], stats.rank([3,5,4,6]));
@@ -243,7 +251,7 @@ describe('stats', function() {
       assert.closeTo( 1, stats.cor(y, y), EPSILON);
       assert.closeTo( 1, stats.cor(z, z), EPSILON);
     });
-    
+
     it('should return NaN with zero-valued input', function() {
       assert(isNaN(stats.cor([0,0,0], [0,0,0])));
       assert(isNaN(stats.cor([0,0,0], [1,2,3])));
@@ -264,7 +272,7 @@ describe('stats', function() {
       assert.equal(-1, stats.cor.rank([1,2,3,4],[8,7,6,5]));
       assert.equal( 0, stats.cor.rank([1,2,3,4],[3,1,4,2]));
     });
-    
+
     it('should accept object array and accessors', function() {
       assert.equal( 1, stats.cor.rank(table, a, b));
       assert.equal(-1, stats.cor.rank(table, a, c));
@@ -293,7 +301,7 @@ describe('stats', function() {
       assert.closeTo(1, stats.cor.dist(x, x), EPSILON);
       assert.closeTo(1, stats.cor.dist(y, y), EPSILON);
     });
-    
+
     it('should return NaN with zero-valued input', function() {
       assert(isNaN(stats.cor.dist([0,0,0], [0,0,0])));
       assert(isNaN(stats.cor.dist([0,0,0], [1,2,3])));
@@ -322,7 +330,7 @@ describe('stats', function() {
       assert.equal(Math.sqrt(8), stats.dist(x, y));
       assert.equal(Math.sqrt(8), stats.dist(y, x));
     });
-    
+
     it('should compute non-Euclidean distances', function() {
       assert.equal(2, stats.dist([1,1], [2,2], 1));
       assert.equal(4, stats.dist([1,1], [2,2], 0.5));
@@ -333,12 +341,12 @@ describe('stats', function() {
   describe('entropy', function() {
     var even = [1, 1, 1, 1, 1, 1], ee = -Math.log(1/6)/Math.LN2;
     var skew = [6, 0, 0, 0, 0, 0], se = 0;
-    
+
     it('should calculate entropy', function() {
       assert.equal(ee, stats.entropy(even));
       assert.equal(se, stats.entropy(skew));
     });
-    
+
     it('should handle accessor argument', function() {
       var wrap = function(a, x) { return (a.push({a:x}), a); };
       assert.equal(ee, stats.entropy(even.reduce(wrap, []), a));
@@ -348,18 +356,18 @@ describe('stats', function() {
     it('should handle zero vectors', function() {
       assert.equal(0, stats.entropy([0,0,0,0]));
     });
-    
+
     it('should handle zero vectors', function() {
       assert.equal(0, stats.entropy([0,0,0,0]));
     });
-    
+
     it('should calculate normalized entropy', function() {
       assert.equal(1, stats.entropy.normalized(even));
       assert.equal(0, stats.entropy.normalized(skew));
       assert.equal(0, stats.entropy.normalized([0,0,0,0]));
     });
   });
-  
+
   describe('entropy.mutual', function() {
     var table = [
       {a:'a', b:1, c:1, d:1},

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -400,6 +400,11 @@ describe('stats', function() {
       assert.deepEqual([2.50, 5.50], stats.profile([1,2,3,4,5,6,7]).iqr);
       assert.deepEqual([2.75, 6.25], stats.profile([1,2,3,4,5,6,7,8]).iqr);
     });
+
+    it('should add maxlength for strings', function () {
+      assert.equal(7, stats.profile(['aa','bbbbbbb', 'ccc']).length.max);
+      assert.equal(2, stats.profile(['aa','bbbbbbb', 'ccc']).length.min);
+    }); 
   });
 
 });


### PR DESCRIPTION
Max length is useful for visualization layout.  

I want to eliminate vl.data.getStats from vegalite and only use `dl.profile` instead.
