### PR TITLE
Script for publishing that works for both npm and bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "datalib",
-  "main": "src/index.js",
+  "main": "datalib.js",
   "version": "1.0.11",
   "homepage": "http://github.com/uwdata/datalib.git",
   "authors": [

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,21 @@
+# update on npm
+npm publish
+
+# read version
+gitsha=$(git rev-parse HEAD)
+version=$(cat package.json | jq .version | sed -e 's/^"//'  -e 's/"$//')
+
+gulp build
+# swap to head so we don't commit compiled file to master along with tags
+git checkout head
+
+# add the compiled files, commit and tag!
+git add datalib* -f
+git commit -m "release $version $gitsha"
+git tag -am "Release v$version." "v$version"
+
+# now swap back to the clean master and push the new tag
+git checkout master
+git push --tags
+
+# Woo hoo! Now the published tag contains compiled files which works great with bower.


### PR DESCRIPTION
- add script for publishing that works for both npm and bower

- I’ve also updated the `v1.0.11` tag to include compiled files to test.  
Now running `bower install datalib` would include `datalib.js`.  

- I also point `bower.json`’s `main` to the compiled `datalib.js`.

![package_json_ _voyager](https://cloud.githubusercontent.com/assets/111269/7546109/680ea622-f58f-11e4-8807-bdfcb50a404f.png)


