### PR TITLE
Change NaN detection in isValid to work in Safari

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -102,7 +102,7 @@ u.isDate = function(obj) {
 };
 
 u.isValid = function(obj) {
-  return obj != null && (obj !== Number(obj) || !isNaN(obj));
+  return obj != null && (typeof(obj) !== 'number' || !isNaN(obj));
 };
 
 u.isBuffer = (Buffer && Buffer.isBuffer) || u.false;

--- a/src/util.js
+++ b/src/util.js
@@ -102,7 +102,7 @@ u.isDate = function(obj) {
 };
 
 u.isValid = function(obj) {
-  return obj != null && !Number.isNaN(obj);
+  return obj != null && (obj !== Number(obj) || !isNaN(obj));
 };
 
 u.isBuffer = (Buffer && Buffer.isBuffer) || u.false;


### PR DESCRIPTION
Safari doesn't implement Number.isNaN (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN), so re-implemented it with a combination is global isNaN (which performs type coercion) and checking to see if object is a number.