### PR TITLE
Add encoding to fs.readFile

### DIFF
--- a/src/import/load.js
+++ b/src/import/load.js
@@ -137,7 +137,7 @@ function file(filename, callback) {
   if (!callback) {
     return fs.readFileSync(filename, 'utf8');
   }
-  require('fs').readFile(filename, callback);
+  require('fs').readFile(filename, 'utf8', callback);
 }
 
 function http(url, callback) {


### PR DESCRIPTION
Without an encoding, `dl.load` returns `Buffer`